### PR TITLE
Error should still be throw when allowEmptyValues is true and a value…

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,9 +25,10 @@ module.exports = {
     dotenv.load(options);
     var sampleVars = dotenv.parse(fs.readFileSync(options.sample || '.env.example'));
     var allowEmptyValues = options.allowEmptyValues || false;
-    var missing = difference(Object.keys(sampleVars), Object.keys(compact(process.env)));
+    var processEnv = allowEmptyValues ? process.env : compact(process.env);
+    var missing = difference(Object.keys(sampleVars), Object.keys(processEnv));
 
-    if (missing.length > 0 && !allowEmptyValues) {
+    if (missing.length > 0) {
       throw new Error('Missing environment variables: ' + missing.join(', '));
     }
     return true;

--- a/test/index.js
+++ b/test/index.js
@@ -40,4 +40,17 @@ describe('dotenv-safe', function () {
             /Missing environment variables/
         );
     });
+
+    it('throws error when a variable does not exist and allowEmptyValues option is true', function () {
+        assert.throws(
+            function () {
+                dotenv.load({
+                    sample: '.env.fail',
+                    allowEmptyValues: true
+                });
+                // Consider providing an Error class
+            },
+            /Missing environment variables/
+        );
+    });
 });


### PR DESCRIPTION
I'm not sure if this was intended behavior, but setting allowEmptyValues to true will ignore all errors. What I expected the option to do was only ignore an error if it was thrown as a result of a value being an empty string.

I modified the code to do that.