### PR TITLE
update dotenv to "^2.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Rodrigo López Dato <rlopezdato@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "dotenv": "^1.2.0"
+    "dotenv": "^2.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
This fixes a bug where env vars are not set when they start with
 non alpha-numeric characters like "\" or "$"