### PR TITLE
Fix for issue 25

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
         if (dotenvResult.error) {
             dotenvResult.parsed = {};
         }
-        var sample = options.sample || '.env.example';
+        var sample = options.sample || options.path + '.example' || '.env.example';
         var sampleVars = dotenv.parse(fs.readFileSync(sample));
         var allowEmptyValues = options.allowEmptyValues || false;
         var processEnv = allowEmptyValues ? process.env : compact(process.env);


### PR DESCRIPTION
Code fix for issue 25, where dotenv-safe doesn't support custom paths to the .env file, even though dotenv does.