### PR TITLE
Teach allowEmptyValues to be an array of optional vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,17 @@ function difference (arrA, arrB) {
     return arrA.filter(a => arrB.indexOf(a) < 0);
 }
 
-function compact (obj) {
+function maybeRemoveEmptyValues (obj, allowEmptyValues) {
+    function allowIfEmpty (key) {
+        return (
+            allowEmptyValues === true ||
+            (Array.isArray(allowEmptyValues) && allowEmptyValues.includes(key))
+        );
+    }
+
     const result = {};
     Object.keys(obj).forEach(key => {
-        if (obj[key]) {
+        if (obj[key] || allowIfEmpty(key)) {
             result[key] = obj[key];
         }
     });
@@ -23,7 +30,7 @@ module.exports = {
         const dotenvResult = dotenv.load(options);
         const example = options.example || options.sample || '.env.example';
         const allowEmptyValues = options.allowEmptyValues || false;
-        const processEnv = allowEmptyValues ? process.env : compact(process.env);
+        const processEnv = maybeRemoveEmptyValues(process.env, allowEmptyValues);
         const exampleVars = dotenv.parse(fs.readFileSync(example));
         const missing = difference(Object.keys(exampleVars), Object.keys(processEnv));
 

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,14 @@ describe('dotenv-safe', () => {
         }));
     });
 
+    it('does not throw error when a variable does not exist and allowEmptyValues option allows it', () => {
+        assert.isOk(dotenv.load({
+            example: 'envs/.env.allowEmpty',
+            path: 'envs/.env',
+            allowEmptyValues: ['EMPTY']
+        }));
+    });
+
     it('throws error when a variable is missing', () => {
         assert.throws(() => {
             dotenv.load({
@@ -81,6 +89,16 @@ describe('dotenv-safe', () => {
                 example: 'envs/.env.fail',
                 path: 'envs/.env',
                 allowEmptyValues: true
+            });
+        }, MissingEnvVarsError);
+    });
+
+    it('throws error when a variable does not exist and allowEmptyValues option does not allows it', () => {
+        assert.throws(() => {
+            dotenv.load({
+                example: 'envs/.env.allowEmpty',
+                path: 'envs/.env',
+                allowEmptyValues: []
             });
         }, MissingEnvVarsError);
     });


### PR DESCRIPTION
It happened to me several times that I needed to be able to leave a variable empty (for example an optional Sentry DSN). The issues and PRs on this repo seem to suggest that I'm not the only one that has this need.

This patch allows to specify an array of optional variables in `allowEmptyValues`, while being backward-compatible.