### PR TITLE
Add `optionalValues` and `requiredValues` options

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,8 @@ module.exports = {
   "extends": "eslint:recommended",
   "env": {
     "node": true,
-    "mocha": true
+    "mocha": true,
+    "es6": true
   },
   "rules": {
     "no-trailing-spaces": "error",

--- a/MissingEnvVarsError.js
+++ b/MissingEnvVarsError.js
@@ -7,7 +7,12 @@ function MissingEnvVarsError (allowEmptyValues, dotenvFilename, exampleFilename,
 Make sure to add them to ${dotenvFilename} or directly to the environment.`;
     const allowEmptyValuesMessage = !allowEmptyValues ? `If you expect any of these variables to be empty, you can use the allowEmptyValues option:
 require('dotenv-safe').config({
-  allowEmptyValues: true
+    allowEmptyValues: true
+});
+
+Or the optionalValues option:
+require('dotenv-safe').config({
+    optionalValues: new Set(['THIS_ENV_IS_OPTIONAL', 'THIS_ONE_TOO'])
 });` : '';
     const envErrorMessage = error ? `Also, the following error was thrown when trying to read variables from  ${dotenvFilename}:\n${error.message}` : '';
     Error.call(this);

--- a/README.markdown
+++ b/README.markdown
@@ -45,7 +45,12 @@ Make sure to add them to .env or directly to the environment.
 
 If you expect any of these variables to be empty, you can use the allowEmptyValues option:
 require('dotenv-safe').config({
-  allowEmptyValues: true
+    allowEmptyValues: true
+});
+
+Or the optionalValues option:
+require('dotenv-safe').config({
+    optionalValues: new Set(['THIS_ENV_IS_OPTIONAL', 'THIS_ONE_TOO'])
 });
 ```
 
@@ -71,8 +76,8 @@ Otherwise, returns an object with the following format:
 
 ```js
 {
-  parsed: { SECRET: 'topsecret', TOKEN: '' },          // parsed representation of .env
-  required: { SECRET: 'topsecret', TOKEN: 'external' } /* key-value pairs required by .env.example
+    parsed: { SECRET: 'topsecret', TOKEN: '' },          // parsed representation of .env
+    required: { SECRET: 'topsecret', TOKEN: 'external' } /* key-value pairs required by .env.example
                                                           and defined by environment */
 }
 ```
@@ -101,7 +106,7 @@ For example:
 
 ```js
 require('dotenv-safe').config({
-  example: process.env.CI ? '.env.ci.example' : '.env.example'
+    example: process.env.CI ? '.env.ci.example' : '.env.example'
 });
 ```
 
@@ -110,8 +115,26 @@ require('dotenv-safe').config({
 [Same options and methods supported by `dotenv`](https://github.com/motdotla/dotenv#options).
 
 ```js
+// Any value can be empty
 require('dotenv-safe').config({
     allowEmptyValues: true,
+    example: './.my-env-example-filename'
+});
+```
+
+```js
+// Any value can be empty except `THIS_ENV_IS_REQUIRED_ANYWAY` and `THIS_ONE_TOO`
+require('dotenv-safe').config({
+    allowEmptyValues: true,
+    requiredValues: new Set(['THIS_ENV_IS_REQUIRED_ANYWAY', 'THIS_ONE_TOO']),
+    example: './.my-env-example-filename'
+});
+```
+
+```js
+// Every values are required except `THIS_ENV_IS_OPTIONAL` and `THIS_ONE_TOO`
+require('dotenv-safe').config({
+    optionalValues: new Set(['THIS_ENV_IS_OPTIONAL', 'THIS_ONE_TOO']),
     example: './.my-env-example-filename'
 });
 ```
@@ -119,11 +142,25 @@ require('dotenv-safe').config({
 ## `allowEmptyValues`
 
 If a variable is defined in the example file and has an empty value in the environment, enabling this option will not throw an error after loading.
+
 Defaults to `false`.
+
+## `optionalValues`
+
+If a variable is defined in the example file and has an empty value in the environment, adding it to this set will not throw an error after loading.
+
+Defaults to `new Set()`.
+
+## `requiredValues`
+
+If [`allowEmptyValues`](#allowEmptyValues) option is `true` but you still require some values to not be empty, adding it to this set will throw an error after loading if the value is empty.
+
+Defaults to `new Set()`.
 
 ## `example`
 
 Path to example environment file.
+
 Defaults to `.env.example`.
 
 # Motivation

--- a/index.js
+++ b/index.js
@@ -4,21 +4,42 @@ const dotenv = require('dotenv');
 const fs = require('fs');
 const MissingEnvVarsError = require('./MissingEnvVarsError.js');
 
+/**
+ * @param {string[]} arrA
+ * @param {string[]} arrB
+ */
 function difference (arrA, arrB) {
     return arrA.filter(a => arrB.indexOf(a) < 0);
 }
 
-function maybeRemoveEmptyValues (obj, allowEmptyValues) {
-    function allowIfEmpty (key) {
+/**
+ * @param {Set<string>} optionalValues
+ * @param {Set<string>} requiredValues
+ */
+function checkOptionalValuesAreNotRequiredToo (optionalValues, requiredValues) {
+    const commonValues = [];
+    optionalValues.forEach((optional) => requiredValues.has(optional) && commonValues.push(optional));
+    if (commonValues.length > 0)
+        throw new Error(`Values cannot be in optionalValues and requiredValues at the same time.
+Values in both options: ${commonValues.join(', ')}`);
+}
+
+/**
+ * @param {Record<string, string>} obj
+ * @param {{ allowEmptyValues: boolean; optionalValues: Set<string>; requiredValues: Set<string> }} config
+ * @returns {Record<string, string>}
+ */
+function selectValues (obj, config) {
+    function allowIfCanBeEmpty (key) {
         return (
-            allowEmptyValues === true ||
-            (Array.isArray(allowEmptyValues) && allowEmptyValues.includes(key))
+            (config.allowEmptyValues === true && !config.requiredValues.has(key))
+            || config.optionalValues.has(key)
         );
     }
 
     const result = {};
     Object.keys(obj).forEach(key => {
-        if (obj[key] || allowIfEmpty(key)) {
+        if (obj[key] || allowIfCanBeEmpty(key)) {
             result[key] = obj[key];
         }
     });
@@ -29,8 +50,25 @@ module.exports = {
     config: function(options = {}) {
         const dotenvResult = dotenv.config(options);
         const example = options.example || options.sample || '.env.example';
+
         const allowEmptyValues = options.allowEmptyValues || false;
-        const processEnv = maybeRemoveEmptyValues(process.env, allowEmptyValues);
+        const optionalValues = options.optionalValues || new Set();
+        const requiredValues = options.requiredValues || new Set();
+
+        if (!(requiredValues instanceof Set) || !(optionalValues instanceof Set))
+            throw new Error('Options requiredValues and optionalValues must be a Set.');
+
+        if (!allowEmptyValues && requiredValues.size > 0)
+            throw new Error('Option requiredValues is useless if allowEmptyValues option is false. All values are required by default.');
+
+        checkOptionalValuesAreNotRequiredToo(requiredValues, optionalValues);
+
+        const processEnv = selectValues(process.env, {
+            allowEmptyValues,
+            optionalValues,
+            requiredValues
+        });
+
         const exampleVars = dotenv.parse(fs.readFileSync(example));
         const missing = difference(Object.keys(exampleVars), Object.keys(processEnv));
 

--- a/index.js
+++ b/index.js
@@ -8,10 +8,17 @@ function difference (arrA, arrB) {
     return arrA.filter(a => arrB.indexOf(a) < 0);
 }
 
-function compact (obj) {
+function maybeRemoveEmptyValues (obj, allowEmptyValues) {
+    function allowIfEmpty (key) {
+        return (
+            allowEmptyValues === true ||
+            (Array.isArray(allowEmptyValues) && allowEmptyValues.includes(key))
+        );
+    }
+
     const result = {};
     Object.keys(obj).forEach(key => {
-        if (obj[key]) {
+        if (obj[key] || allowIfEmpty(key)) {
             result[key] = obj[key];
         }
     });
@@ -23,7 +30,7 @@ module.exports = {
         const dotenvResult = dotenv.load(options);
         const example = options.example || options.sample || '.env.example';
         const allowEmptyValues = options.allowEmptyValues || false;
-        const processEnv = allowEmptyValues ? process.env : compact(process.env);
+        const processEnv = maybeRemoveEmptyValues(process.env, allowEmptyValues);
         const exampleVars = dotenv.parse(fs.readFileSync(example));
         const missing = difference(Object.keys(exampleVars), Object.keys(processEnv));
 

--- a/test/index.js
+++ b/test/index.js
@@ -48,6 +48,14 @@ describe('dotenv-safe', () => {
         }));
     });
 
+    it('does not throw error when a variable exists but is empty and optionalValues option allows it', () => {
+        assert.isOk(dotenv.config({
+            example: 'envs/.env.allowEmpty',
+            path: 'envs/.env',
+            optionalValues: new Set(['EMPTY'])
+        }));
+    });
+
     it('does not throw error when .env is missing but variables exist', () => {
         process.env.HELLO = 'WORLD';
 
@@ -56,29 +64,11 @@ describe('dotenv-safe', () => {
         }));
     });
 
-    it('does not throw error when a variable does not exist and allowEmptyValues option allows it', () => {
-        assert.isOk(dotenv.load({
-            example: 'envs/.env.allowEmpty',
-            path: 'envs/.env',
-            allowEmptyValues: ['EMPTY']
-        }));
-    });
-
     it('throws error when a variable is missing', () => {
         assert.throws(() => {
             dotenv.config({
                 example: 'envs/.env.fail',
                 path: 'envs/.env'
-            });
-        }, MissingEnvVarsError);
-    });
-
-    it('throws error when a variable exists but is empty and allowEmptyValues option is false', () => {
-        assert.throws(() => {
-            dotenv.config({
-                example: 'envs/.env.allowEmpty',
-                path: 'envs/.env',
-                allowEmptyValues: false
             });
         }, MissingEnvVarsError);
     });
@@ -93,14 +83,76 @@ describe('dotenv-safe', () => {
         }, MissingEnvVarsError);
     });
 
-    it('throws error when a variable does not exist and allowEmptyValues option does not allows it', () => {
+    it('throws error when a variable exists but is empty and allowEmptyValues option is false', () => {
         assert.throws(() => {
-            dotenv.load({
+            dotenv.config({
                 example: 'envs/.env.allowEmpty',
                 path: 'envs/.env',
-                allowEmptyValues: []
+                allowEmptyValues: false
             });
         }, MissingEnvVarsError);
+    });
+
+    it('throws error when a variable exists but is empty and allowEmptyValues option is true but is required in requiredValues', () => {
+        assert.throws(() => {
+            dotenv.config({
+                example: 'envs/.env.allowEmpty',
+                path: 'envs/.env',
+                allowEmptyValues: true,
+                requiredValues: new Set(['EMPTY'])
+            });
+        }, MissingEnvVarsError);
+    });
+
+    it('throws error when a variable does not exist and optionalValues option does not allows it', () => {
+        assert.throws(() => {
+            dotenv.config({
+                example: 'envs/.env.allowEmpty',
+                path: 'envs/.env',
+                optionalValues: new Set()
+            });
+        }, MissingEnvVarsError);
+    });
+
+    it('throws error when optionalValues option is not a Set', () => {
+        assert.throws(() => {
+            dotenv.config({
+                example: 'envs/.env.success',
+                path: 'envs/.env',
+                optionalValues: ['HELLO']
+            });
+        }, Error);
+    });
+
+    it('throws error when requiredValues option is not a Set', () => {
+        assert.throws(() => {
+            dotenv.config({
+                example: 'envs/.env.success',
+                path: 'envs/.env',
+                requiredValues: ['HELLO']
+            });
+        }, Error);
+    });
+
+    it('throws error when allowEmptyValues option it false but requiredValues option is not empty (all values are required as default)', () => {
+        assert.throws(() => {
+            dotenv.config({
+                example: 'envs/.env.success',
+                path: 'envs/.env',
+                requiredValues: new Set(['HELLO'])
+            });
+        }, Error);
+    });
+
+    it('throws error when a variable is in optionalValues option and requiredValues option at the same time', () => {
+        assert.throws(() => {
+            dotenv.config({
+                example: 'envs/.env.success',
+                path: 'envs/.env',
+                optionalValues: new Set(['HELLO']),
+                requiredValues: new Set(['HELLO'])
+            });
+        }, Error);
     });
 
     it('returns an object with parsed .env', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,14 @@ describe('dotenv-safe', () => {
         }));
     });
 
+    it('does not throw error when a variable does not exist and allowEmptyValues option allows it', () => {
+        assert.isOk(dotenv.load({
+            example: 'envs/.env.allowEmpty',
+            path: 'envs/.env',
+            allowEmptyValues: ['EMPTY']
+        }));
+    });
+
     it('throws error when a variable is missing', () => {
         assert.throws(() => {
             dotenv.load({
@@ -81,6 +89,16 @@ describe('dotenv-safe', () => {
                 example: 'envs/.env.fail',
                 path: 'envs/.env',
                 allowEmptyValues: true
+            });
+        }, MissingEnvVarsError);
+    });
+
+    it('throws error when a variable does not exist and allowEmptyValues option does not allows it', () => {
+        assert.throws(() => {
+            dotenv.load({
+                example: 'envs/.env.allowEmpty',
+                path: 'envs/.env',
+                allowEmptyValues: []
             });
         }, MissingEnvVarsError);
     });


### PR DESCRIPTION
Closes #41 #45

First, thank you for this lib, I use it on almost every projects of mine! 😊

This PR adds the options `optionalValues` and `requiredValues`. I thought it would be better to not allow `allowEmptyValues` to be a `Set` just like in #41, and make it new separate options.

## How it works

 - Uses `Set` as mentioned in #41
 - `optionalValues`: Values in `optionalValues` will not be required anymore
 - `allowEmptyValues` + `requiredValues`: All values are optional except ones in `requiredValues`

## Errors

 - `allowEmptyValues` + `optionalValues`: Error, useless as all are already option
 - `optionalValues` + `requiredValues`: Error, can't be in both options
 - `allowEmptyValues=false` + `requiredValues`: Error, everything is already required
 - `optionalValues` or `requiredValues` are not Set: Error, must be `Set`

Let me know what you think of it 😄