### PR TITLE
Fixing link to --require docs in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -91,7 +91,7 @@ This is the preferred approach when using import instead of require.
 $ node -r dotenv-safe/config your_script.js
 ```
 
-[See the dotenv README for more information]((https://github.com/motdotla/dotenv#preload)).
+[See the dotenv README for more information](https://github.com/motdotla/dotenv#preload).
 
 ## Continuous integration (CI)
 


### PR DESCRIPTION
Super-minor fix to link syntax in README.