### PR TITLE
Add support for `example` option passed through env variable

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,10 @@
 (function () {
     var options = {};
+
+    if (process.env.DOTENV_CONFIG_EXAMPLE != null) {
+        options.example = process.env.DOTENV_CONFIG_EXAMPLE;
+    }
+
     process.argv.forEach(function (val) {
         var matches = val.match(/^dotenv_config_(.+)=(.+)/);
         if (matches) {


### PR DESCRIPTION
There is currently no way to set the `example` option using an env variable. As rightly pointed out here in [this issue](https://github.com/rolodato/dotenv-safe/issues/126#issuecomment-1930229904), `DOTENV_CONFIG_PATH` is supported thanks to `dotenv`, but since it is not aware of `dotenv-safe`'s `example` option this one is ignored.

I added the support for `DOTENV_CONFIG_EXAMPLE` in `dotenv-safe/config.js`. I got inspiration from what is done in [`dotenv/config.js`](https://github.com/motdotla/dotenv/blob/fe58fef9e2aaf657b6371f7a2f2de8862042878e/config.js) being more restrictive than my initial patch and only explicitly supporting `DOTENV_CONFIG_EXAMPLE`

`config.js` is not covered by the current test suite so I'm unsure how to proceed. The manual way of testing is typically the following command:
```bash
DOTENV_CONFIG_PATH=src/.deploy.env DOTENV_CONFIG_EXAMPLE=src/.deploy.env.example node --require dotenv/config --require dotenv-safe/config src/myApp.js
```
It would fail before with `Error: ENOENT: no such file or directory, open '.env.example'` but is now supported.

closes https://github.com/rolodato/dotenv-safe/issues/126#issuecomment-1938266585