### PR TITLE
Instruct users to also install dotenv

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,15 +8,15 @@ The names of the needed variables are read from `.env.example`, which should be 
 # Installation
 
 ```
-npm install dotenv-safe
+npm install dotenv-safe dotenv
 ```
 
 ```
-pnpm install dotenv-safe
+pnpm install dotenv-safe dotenv
 ```
 
 ```
-yarn add dotenv-safe
+yarn add dotenv-safe dotenv
 ```
 
 # Example


### PR DESCRIPTION
Hey there 👋

Since `dotenv` is a peer dependency now, to use `dotenv-safe` users will also need to install `dotenv`.
Currently this is not entirely clear from the installation instructions.

It's nice as a (first time) user to copy paste the installation instructions and have it work.
Currently, when blindly follow the instructions, they'll either get a warning from their package manager or a runtime error when trying to use `dotenv-safe`.